### PR TITLE
Fix jQuery when served over https

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,7 +184,7 @@
 </section>
 
 </body>
-<script type="text/javascript" src="http://code.jquery.com/jquery-1.11.0.min.js"></script>
+<script type="text/javascript" src="//code.jquery.com/jquery-1.11.0.min.js"></script>
 <script type="text/javascript" src="assets/site.js"></script>
 <script type="text/javascript">
 var _gaq = _gaq || [];


### PR DESCRIPTION
If a page is served over https then Chrome will not load any javascript loaded over http. Use a protocol relative URL for jQuery, so it gets loaded over the same protocol as the main page.
