### PR TITLE
ensures the devices displays correctly

### DIFF
--- a/assets/scss/devices.scss
+++ b/assets/scss/devices.scss
@@ -3,6 +3,9 @@
 .marvel-device{
 	display: inline-block;
 	position: relative;
+	-webkit-box-sizing: content-box;
+	-moz-box-sizing: content-box;
+	box-sizing: content-box;
 
 	.screen {
 		width: 100%;


### PR DESCRIPTION
Many frameworks use the following css which screws up the devices
```
*, *:before, *:after {box-sizing: border-box}
```