### PR TITLE
Tweak to the z-index of the iPhoneX notch visible

### DIFF
--- a/assets/scss/devices.scss
+++ b/assets/scss/devices.scss
@@ -2312,7 +2312,7 @@
 			height: 30px;
 			top: 26px;
 			left: 108px;
-			z-index: 3;
+			z-index: 4;
 			background: black;
 			border-bottom-left-radius: 24px;
 		    border-bottom-right-radius: 24px;


### PR DESCRIPTION
Just a tweak to make the z-index of the notch one greater so it is visible.

I noticed the notch isn't visible on Linux with Chrome 62.0.3202.94 (Official Build) (64-bit) and Linux with FireFox 57.0.1, see screen grabs below.

![screenshot_2017-12-18_17-38-01](https://user-images.githubusercontent.com/91541/34119484-3d45e2b2-e41a-11e7-92d1-46f9a2f53a32.png)
![screenshot_2017-12-18_17-37-34](https://user-images.githubusercontent.com/91541/34119485-3d62767a-e41a-11e7-8099-89fa94e48a24.png)
